### PR TITLE
Adding Options Pass Through param for Cors library in both OAth and P…

### DIFF
--- a/pkg/plugin/cors/setup.go
+++ b/pkg/plugin/cors/setup.go
@@ -8,10 +8,11 @@ import (
 
 // Config represents the CORS configuration
 type Config struct {
-	AllowedOrigins []string `json:"domains"`
-	AllowedMethods []string `json:"methods"`
-	AllowedHeaders []string `json:"request_headers"`
-	ExposedHeaders []string `json:"exposed_headers"`
+	AllowedOrigins     []string `json:"domains"`
+	AllowedMethods     []string `json:"methods"`
+	AllowedHeaders     []string `json:"request_headers"`
+	ExposedHeaders     []string `json:"exposed_headers"`
+	OptionsPassthrough bool     `json:"options_passthrough"`
 }
 
 func init() {
@@ -29,11 +30,12 @@ func setupCors(def *proxy.RouterDefinition, rawConfig plugin.Config) error {
 	}
 
 	mw := cors.New(cors.Options{
-		AllowedOrigins:   config.AllowedOrigins,
-		AllowedMethods:   config.AllowedMethods,
-		AllowedHeaders:   config.AllowedHeaders,
-		ExposedHeaders:   config.ExposedHeaders,
-		AllowCredentials: true,
+		AllowedOrigins:     config.AllowedOrigins,
+		AllowedMethods:     config.AllowedMethods,
+		AllowedHeaders:     config.AllowedHeaders,
+		ExposedHeaders:     config.ExposedHeaders,
+		OptionsPassthrough: config.OptionsPassthrough,
+		AllowCredentials:   true,
 	})
 
 	def.AddMiddleware(mw.Handler)

--- a/pkg/plugin/cors/setup_test.go
+++ b/pkg/plugin/cors/setup_test.go
@@ -11,10 +11,11 @@ import (
 func TestConfig(t *testing.T) {
 	var config Config
 	rawConfig := map[string]interface{}{
-		"domains":         []string{"*"},
-		"methods":         []string{"GET"},
-		"request_headers": []string{"Content-Type", "Authorization"},
-		"exposed_headers": []string{"Test"},
+		"domains":             []string{"*"},
+		"methods":             []string{"GET"},
+		"request_headers":     []string{"Content-Type", "Authorization"},
+		"exposed_headers":     []string{"Test"},
+		"options_passthrough": true,
 	}
 
 	err := plugin.Decode(rawConfig, &config)
@@ -31,6 +32,8 @@ func TestConfig(t *testing.T) {
 
 	assert.IsType(t, []string{}, config.ExposedHeaders)
 	assert.Equal(t, []string{"Test"}, config.ExposedHeaders)
+
+	assert.True(t, config.OptionsPassthrough)
 }
 
 func TestInvalidConfig(t *testing.T) {
@@ -43,12 +46,28 @@ func TestInvalidConfig(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestSetup(t *testing.T) {
+func TestEmptyPassthrough(t *testing.T) {
+	var config Config
 	rawConfig := map[string]interface{}{
 		"domains":         []string{"*"},
 		"methods":         []string{"GET"},
 		"request_headers": []string{"Content-Type", "Authorization"},
 		"exposed_headers": []string{"Test"},
+	}
+
+	err := plugin.Decode(rawConfig, &config)
+	assert.NoError(t, err)
+
+	assert.False(t, config.OptionsPassthrough)
+}
+
+func TestSetup(t *testing.T) {
+	rawConfig := map[string]interface{}{
+		"domains":             []string{"*"},
+		"methods":             []string{"GET"},
+		"request_headers":     []string{"Content-Type", "Authorization"},
+		"exposed_headers":     []string{"Test"},
+		"options_passthrough": true,
 	}
 	def := proxy.NewRouterDefinition(proxy.NewDefinition())
 	err := setupCors(def, rawConfig)

--- a/pkg/plugin/oauth2/loader.go
+++ b/pkg/plugin/oauth2/loader.go
@@ -37,11 +37,12 @@ func (m *OAuthLoader) RegisterOAuthServers(oauthServers []*Spec, repo Repository
 		logger.Debug("Registering OAuth server")
 
 		corsHandler := cors.New(cors.Options{
-			AllowedOrigins:   oauthServer.CorsMeta.Domains,
-			AllowedMethods:   oauthServer.CorsMeta.Methods,
-			AllowedHeaders:   oauthServer.CorsMeta.RequestHeaders,
-			ExposedHeaders:   oauthServer.CorsMeta.ExposedHeaders,
-			AllowCredentials: true,
+		AllowedOrigins:     oauthServer.CorsMeta.Domains,
+		AllowedMethods:     oauthServer.CorsMeta.Methods,
+		AllowedHeaders:     oauthServer.CorsMeta.RequestHeaders,
+		ExposedHeaders:     oauthServer.CorsMeta.ExposedHeaders,
+		OptionsPassthrough: oauthServer.CorsMeta.OptionsPassthrough,
+		AllowCredentials:   true,
 		}).Handler
 
 		mw = append(mw, corsHandler)

--- a/pkg/plugin/oauth2/oauth.go
+++ b/pkg/plugin/oauth2/oauth.go
@@ -57,11 +57,12 @@ type rateLimitMeta struct {
 }
 
 type corsMeta struct {
-	Domains        []string `mapstructure:"domains" bson:"domains" json:"domains"`
-	Methods        []string `mapstructure:"methods" bson:"methods" json:"methods"`
-	RequestHeaders []string `mapstructure:"request_headers" bson:"request_headers" json:"request_headers"`
-	ExposedHeaders []string `mapstructure:"exposed_headers" bson:"exposed_headers" json:"exposed_headers"`
-	Enabled        bool     `bson:"enabled" json:"enabled"`
+	Domains            []string `mapstructure:"domains" bson:"domains" json:"domains"`
+	Methods            []string `mapstructure:"methods" bson:"methods" json:"methods"`
+	RequestHeaders     []string `mapstructure:"request_headers" bson:"request_headers" json:"request_headers"`
+	ExposedHeaders     []string `mapstructure:"exposed_headers" bson:"exposed_headers" json:"exposed_headers"`
+	OptionsPassthrough bool     `mapstructure:"options_passthrough" bson:"options_passthrough" json:"options_passthrough"`
+	Enabled            bool     `bson:"enabled" json:"enabled"`
 }
 
 // IntrospectionSettings represents the settings for introspection


### PR DESCRIPTION
…lugins

## What does this PR do?
This allows Janus to forward the OptionsPassThrough param to the Cors library.

The changes are in both the Cors plugin, and in the OAuth2 plugin.

The Cors plugin is fully tested. The Oauth2 plugin is difficult to test.
